### PR TITLE
fix firsttime to not throw syntax error 

### DIFF
--- a/post_install/firsttime
+++ b/post_install/firsttime
@@ -39,9 +39,8 @@ then
 	echo ""
         echo "you MUST first set the root password"
         echo ""
-	echo -n "Would you like to do this now (Y/N)? "
-	read ANSWER
-	if [ $ANSWER = Y ] || [ $ANSWER = y ]
+	promptyn "Would you like to do this now"
+	if [ $ANSWER = Y ]
 	then
 		while ! passwd
 		do


### PR DESCRIPTION
...on empty answer to password change prompt

Of you just hit enter for the password change prompt this results:
```
line 44 [: =: unary operator expected
```
This commit just reuses the `promptyn` fuction.